### PR TITLE
Fix bug that lead to crashed in getBestClustering

### DIFF
--- a/diarizationFunctions.py
+++ b/diarizationFunctions.py
@@ -514,7 +514,19 @@ def getBestClustering(bestClusteringMetric, bkT, cvT, clusteringTable, n, maxNrS
     nrSpeakersPerSolution = np.zeros((clusteringTable.shape[1]))
     for k in np.arange(clusteringTable.shape[1]):
         nrSpeakersPerSolution[k] = np.size(np.unique(clusteringTable[:,k]))
-    bestClusteringID = np.maximum(np.where(nrSpeakersPerSolution==np.maximum(np.minimum(maxNrSpeakers,np.max(nrSpeakersPerSolution))-1,1))[0][0],bestClusteringID)
+
+    maxAllowedSpeakers = np.maximum(
+        np.minimum(maxNrSpeakers, np.max(nrSpeakersPerSolution)), 1
+    ) - 1
+    firstAllowedClustering = np.min(
+        np.where(nrSpeakersPerSolution <= maxAllowedSpeakers)
+    )
+    # Note: clusters are ordered from most clusters to least, so this selects the bestClusteringID
+    # unless it has more than maxNrSpeakers nodes, in which case it selects firstAllowedClustering
+    bestClusteringID = np.maximum(
+        firstAllowedClustering,
+        bestClusteringID
+    )
     return bestClusteringID
   
 def getSpectralClustering(bestClusteringMetric,clusteringTable,N_init, bkT, cvT, n, sigma, percentile,maxNrSpeakers):


### PR DESCRIPTION
This is the same bugfix as in https://github.com/audapolis/pydiar/pull/2/files#diff-1b33447d4f81a572a4bd2efcfc589429bd23238f3127b848463ad6a08e6d131bR446